### PR TITLE
input and output list sorted by pk

### DIFF
--- a/aiida_graph_browser.ipynb
+++ b/aiida_graph_browser.ipynb
@@ -69,12 +69,14 @@
     "        self.stack_list = stack_list\n",
     "        self.links = OrderedDict()\n",
     "        self.links[\"Select a link\"] = None\n",
-    "        for i, kv in enumerate(node.get_inputs(also_labels=True)):\n",
-    "            self.links[\"in:%s [%d]\"%(kv[0],i)] = kv[1]\n",
+    "        sorted_inputs = sorted([(n_inp.pk, label, n_inp) for label, n_inp in node.get_inputs(also_labels=True)])\n",
+    "        for i, kv in enumerate(sorted_inputs):\n",
+    "            self.links[\"in:%s [%d]\"%(kv[1],i)] = kv[2]\n",
     "        \n",
     "        self.links[50*\"-\"] = None\n",
-    "        for i, kv in enumerate(node.get_outputs(also_labels=True)):\n",
-    "            self.links[\"out:%s [%d]\"%(kv[0],i)] = kv[1]\n",
+    "        sorted_outputs = sorted([(n_out.pk, label, n_out) for label, n_out in node.get_outputs(also_labels=True)])\n",
+    "        for i, kv in enumerate(sorted_outputs):\n",
+    "            self.links[\"out:%s [%d]\"%(kv[1],i)] = kv[2]\n",
     "        self.inp_links = ipw.Dropdown(options=self.links)\n",
     "        \n",
     "        self.inp_links.observe(self.on_change, \"value\")\n",
@@ -198,7 +200,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.13"
+   "version": "2.7.15rc1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hi!

When doing `node.get_outputs(also_labels=True)`, the outputs with labels aren't necessarily returned in order of execution (this happened to me in our nanoribbon workflow, where it was difficult to find the "correct" CALL as they were ordered randomly). Therefore I added a sort based on the PKs.

regards,
Kristjan
